### PR TITLE
Fix stray '(' in paypal-handle-order URL pattern

### DIFF
--- a/paypal/express/urls.py
+++ b/paypal/express/urls.py
@@ -20,7 +20,7 @@ base_patterns = [
 
 
 buyer_pays_on_paypal_patterns = [
-    path('handle-order/(<int:basket_id>/', views.SuccessResponseView.as_view(preview=True),
+    path('handle-order/<int:basket_id>/', views.SuccessResponseView.as_view(preview=True),
          name='paypal-handle-order'),
 ]
 


### PR DESCRIPTION
## Problem

`buyer_pays_on_paypal_patterns` registers the return route as:

```python
path('handle-order/(<int:basket_id>/', views.SuccessResponseView.as_view(preview=True), name='paypal-handle-order')
```

`path()` treats the `(` as a literal character, so with `PAYPAL_BUYER_PAYS_ON_PAYPAL=True` the reversed return URL contains a stray paren (e.g. `/checkout/paypal/handle-order/(123/`). It is self-consistent (reverse + match use the same literal) but produces an ugly, unintended URL.

## Fix

Drop the stray `(` so the route is `handle-order/<int:basket_id>/`, matching `place-order/` and `preview/`.

## Test plan

- Set `PAYPAL_BUYER_PAYS_ON_PAYPAL=True`
- Reverse `paypal-handle-order` -> `/checkout/paypal/handle-order/<basket_id>/` (no paren)
- Complete the express flow; the PayPal return lands on the order-placement view.